### PR TITLE
[Fix] Add compatible pypandoc version required for pyspark 2.4.5

### DIFF
--- a/jupyterlab.Dockerfile
+++ b/jupyterlab.Dockerfile
@@ -7,7 +7,7 @@ ARG jupyterlab_version=2.1.5
 
 RUN apt-get update -y && \
     apt-get install -y python3-pip && \
-	pip3 install pypandoc && \
+	pip3 install pypandoc==1.5 && \
     pip3 install pyspark==${spark_version} jupyterlab==${jupyterlab_version} && \
 	pip3 install wget && \
     pip3 install numpy && pip3 install pandas && pip3 install matplotlib && \


### PR DESCRIPTION
## Summary
This PR addresses an issue with building `jupyterlab.Dockerfile` whereby the dependency on `pypandoc` is incompatible with `pyspark==2.4.5`.

```
$ ./build.sh

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
[+] Building 39.3s (5/6)                                                                                                                                                                                                                                                                                                                                                        
 => [internal] load build definition from jupyterlab.Dockerfile                                                                                                                                                                                                                                                                                                            0.0s
 => => transferring dockerfile: 661B                                                                                                                                                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/cluster-base:latest                                                                                                                                                                                                                                                                                                     0.0s
 => CACHED [1/3] FROM docker.io/library/cluster-base                                                                                                                                                                                                                                                                                                                       0.0s
 => ERROR [2/3] RUN apt-get update -y &&     apt-get install -y python3-pip &&  pip3 install pypandoc &&     pip3 install pyspark==2.4.5 jupyterlab==2.1.5 &&  pip3 install wget &&     pip3 install numpy && pip3 install pandas && pip3 install matplotlib &&     rm -rf /var/lib/apt/lists/* &&     ln -s /usr/local/bin/python3 /usr/bin/python                       39.2s
------                                                                                                                                                                                                                                                                                                                                                                          
 > [2/3] RUN apt-get update -y &&     apt-get install -y python3-pip &&         pip3 install pypandoc &&     pip3 install pyspark==2.4.5 jupyterlab==2.1.5 &&   pip3 install wget &&     pip3 install numpy && pip3 install pandas && pip3 install matplotlib &&     rm -rf /var/lib/apt/lists/* &&     ln -s /usr/local/bin/python3 /usr/bin/python:                           

...

#5 29.69 Collecting pyspark==2.4.5
#5 29.78   Downloading https://files.pythonhosted.org/packages/9a/5a/271c416c1c2185b6cb0151b29a91fff6fcaed80173c8584ff6d20e46b465/pyspark-2.4.5.tar.gz (217.8MB)
#5 38.91     Complete output from command python setup.py egg_info:
#5 38.91     Traceback (most recent call last):
#5 38.91       File "<string>", line 1, in <module>
#5 38.91       File "/tmp/pip-install-9qru8bua/pyspark/setup.py", line 156, in <module>
#5 38.91         long_description = pypandoc.convert('README.md', 'rst')
#5 38.91     AttributeError: module 'pypandoc' has no attribute 'convert'
#5 38.91     
#5 38.91     ----------------------------------------
#5 38.97 Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-9qru8bua/pyspark/
```

The suggestion here is to downgrade `pypandoc` which has the `convert` library contained.
Ref: https://stackoverflow.com/questions/74745548/attributeerror-module-pypandoc-has-no-attribute-convert

Moving forward, these all dependencies should be explicitly versioned to ensure compatibility during the build phase.